### PR TITLE
 Release tag maintained in republished RFC or IANA YANG module registry 

### DIFF
--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -174,7 +174,7 @@ Instead, a link to a new module draft or updated module draft in the
 above repository <bcp14>MUST</bcp14> be included in the document.
  link <bcp14>MUST</bcp14> point to a specific tagged version of the
 G module (e.g., a git tag or commit hash), not to the HEAD of a branch
-ch is further maintained by IANA YANG module registry, so that the module's
+which is further maintained by IANA YANG module registry, so that the module's
 tents with specific tag version at RFC publication time are permanently
 retrievable and verifiable.
 

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -97,7 +97,7 @@ Guidance for writing YANG modules is discussed in {{!RFC9907}}.
 Guidelines related to code components (section3.2 of {{!RFC9907}})
 or citations to references listed in the YANG module do not apply to VELOCE.
 
-# Conventions and Definitions
+## Conventions and Definitions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
@@ -111,28 +111,23 @@ The following practices should provide the necessary guidance
 on how a WG develops a new YANG module or updates an existing
 YANG module:
 
-It is RECOMMENDED that IETF-hosted repositories
-be used. See section 1.3 of Working Group GitHub Usage
-Guidance {{!RFC8874}}. Integration using third-party hosted
-repositories MAY be used for experimentation purposes.
+It is RECOMMENDED that IETF-hosted repositories be used.
+See section 1.3 of Working Group GitHub Usage
+Guidance {{!RFC8874}}.
+Integration using third-party hosted repositories MAY be used for experimentation purposes.
 
 A new repository MUST be created by the WG
 Chairs following the procedure in section 3.2 of Working Group
 GitHub Usage Guidance {{!RFC8874}} for to develop or maintain a YANG
-Module. For a new module, this SHOULD happen when
-the module is adopted as a WG item. It MAY happen for
-individual drafts, and that is left to the discretion of the
-chairs. However, once the document is adopted as a WG item,
-the repository SHOULD reside under the auspecies
-of IETF controlled repository and managed by the WG. The
-name of the repository SHOULD reflect the name
-of the draft. In addition, the chairs MAY make
-sure that an appropriate CI/CD YANG validation is in place.  It
-is RECOMMENDED that a containerized build
-environment be provided in the repository to enable local
-validation of YANG modules (e.g., via yanglint) independently of
-the CI/CD pipeline, and to ensure a consistent development
-environment across all contributors.
+Module.
+For a new module, this SHOULD happen when the module is adopted as a WG item.
+It MAY happen for individual drafts, and that is left to the discretion of the chairs.
+However, once the document is adopted as a WG item, the repository SHOULD reside under the auspecies
+of IETF controlled repository and managed by the WG.
+The name of the repository SHOULD reflect the name of the draft.
+In addition, the chairs MAY make sure that an appropriate CI/CD YANG validation is in place.
+It is RECOMMENDED that a containerized build environment be provided in the repository to enable local
+validation of YANG modules (e.g., via yanglint) independently of the CI/CD pipeline, and to ensure a consistent development environment across all contributors.
 
 The procedure for managing WG documents (e.g., assign editors)
 applies for managing YANG modules (section 6.1 of IETF Working
@@ -260,9 +255,10 @@ of this experiment, and since the idea is to demonstrate a
 faster way for a new YANG module to be developed, the
 timelines for the experiment are as follows:
 
-A new YANG module should be published within two years
+* A new YANG module should be published within two years
 of the start of the experiment.
-A "bis" version of an existing YANG module, where the
+
+* A "bis" version of an existing YANG module, where the
 primary motivation is incremental updates rather than a
 ground-up redesign, should be published within one year.
 
@@ -310,5 +306,5 @@ This draft is triggered by the discussion in NEMOPS IAB workshop.
 
 Thanks to the participants of OPSAWG for their comments that
 have helped shape this draft.  In particular, thanks to
-Jeffrey Haas, Joe Clarke, Dhruv Dhody, Per Andersson，Italo Busi,
+Jeffrey Haas, Joe Clarke, Dhruv Dhody, Per Andersson, Italo Busi,
 and Mohamed Boucadair for their feedback during IETF 125.

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -175,7 +175,7 @@ above repository <bcp14>MUST</bcp14> be included in the document.
  link <bcp14>MUST</bcp14> point to a specific tagged version of the
 G module (e.g., a git tag or commit hash), not to the HEAD of a branch
 which is further maintained by IANA YANG module registry, so that the module's
-tents with specific tag version at RFC publication time are permanently
+contents with specific tag version at RFC publication time are permanently
 retrievable and verifiable.
 
 YANG SID files {{!RFC9595}}, when applicable (e.g.,

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -262,7 +262,7 @@ of this experiment, and since the idea is to demonstrate a
 faster way for a new YANG module to be developed, the
 timelines for the experiment are as follows:
 
-* A new YANG module should be published within two years
+- A new YANG module should be published within two years
 of the start of the experiment.
 
 * A "bis" version of an existing YANG module, where the

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -168,13 +168,15 @@ A procedure for assessing consensus is discussed in section 7 of Working
 Group GitHub Usage Guidance {{!RFC8874}} and SHOULD be
 followed when accepting changes to the module.
 
-The YANG module MUST NOT be inserted in the
-document; instead, a link to the above repository
-MUST be included in the document.  The link
-MUST point to a specific tagged version of the
-YANG module (e.g., a git tag or commit hash), not to the HEAD of
-a branch, so that the module's contents at RFC publication time
-are permanently retrievable and verifiable.
+When a RFC document is needed for a new module or an updated module,
+the YANG module <bcp14>MUST</bcp14> NOT be inserted in the document;
+tead, a link to a new module draft or updated module draft in the
+ve repository <bcp14>MUST</bcp14> be included in the document.
+ link <bcp14>MUST</bcp14> point to a specific tagged version of the
+G module (e.g., a git tag or commit hash), not to the HEAD of a branch
+ch is further maintained by IANA YANG module registry, so that the module's
+tents with specific tag version at RFC publication time are permanently
+retrievable and verifiable.
 
 YANG SID files {{!RFC9595}}, when applicable (e.g.,
 for YANG/CBOR encoding), SHOULD reside in the

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -171,7 +171,7 @@ followed when accepting changes to the module.
 When a RFC document is needed for a new module or an updated module,
 the YANG module <bcp14>MUST</bcp14> NOT be inserted in the document;
 Instead, a link to a new module draft or updated module draft in the
-ve repository <bcp14>MUST</bcp14> be included in the document.
+above repository <bcp14>MUST</bcp14> be included in the document.
  link <bcp14>MUST</bcp14> point to a specific tagged version of the
 G module (e.g., a git tag or commit hash), not to the HEAD of a branch
 ch is further maintained by IANA YANG module registry, so that the module's

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -120,7 +120,7 @@ A new repository MUST be created by the WG
 Chairs following the procedure in section 3.2 of Working Group
 GitHub Usage Guidance {{!RFC8874}} for to develop or maintain a YANG
 Module.
-For a new module, this SHOULD happen when the module is adopted as a WG item.
+
 It MAY happen for individual drafts, and that is left to the discretion of the chairs.
 However, once the document is adopted as a WG item, the repository SHOULD reside under the auspecies
 of IETF controlled repository and managed by the WG.
@@ -238,6 +238,11 @@ The primary "exit criteria" for the experiment will be
 successful publication of the YANG modules identified as
 part of the experiment, within the timelines defined in
 {{sec-timeline}}.
+
+For an updated module, if IETF YANG model can be updated using an
+IETF WG consensus process (probably including an errata report) and
+WG github without republishing as a new RFC, the experiment should
+also be deemed as success.
 
 Beyond publication, success will also be evaluated based on
 whether the process improved community participation in YANG

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -265,7 +265,7 @@ timelines for the experiment are as follows:
 - A new YANG module should be published within two years
 of the start of the experiment.
 
-* A "bis" version of an existing YANG module, where the
+- A "bis" version of an existing YANG module, where the
 primary motivation is incremental updates rather than a
 ground-up redesign, should be published within one year.
 

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -170,7 +170,7 @@ followed when accepting changes to the module.
 
 When a RFC document is needed for a new module or an updated module,
 the YANG module <bcp14>MUST</bcp14> NOT be inserted in the document;
-tead, a link to a new module draft or updated module draft in the
+Instead, a link to a new module draft or updated module draft in the
 ve repository <bcp14>MUST</bcp14> be included in the document.
  link <bcp14>MUST</bcp14> point to a specific tagged version of the
 G module (e.g., a git tag or commit hash), not to the HEAD of a branch

--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -97,7 +97,7 @@ Guidance for writing YANG modules is discussed in {{!RFC9907}}.
 Guidelines related to code components (section3.2 of {{!RFC9907}})
 or citations to references listed in the YANG module do not apply to VELOCE.
 
-## Conventions and Definitions
+# Conventions and Definitions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
@@ -240,11 +240,6 @@ The primary "exit criteria" for the experiment will be
 successful publication of the YANG modules identified as
 part of the experiment, within the timelines defined in
 {{sec-timeline}}.
-
-For an updated module, if IETF YANG model can be updated using an
-IETF WG consensus process (probably including an errata report) and
-WG github without republishing as a new RFC, the experiment should
-also be deemed as success.
 
 Beyond publication, success will also be evaluated based on
 whether the process improved community participation in YANG


### PR DESCRIPTION
This replaces #28.
