### PR TITLE
chore: redo patch-3 against kramdown. online validation vs local validation

### DIFF
--- a/draft-mahesh-opsawg-veloce-yang.md
+++ b/draft-mahesh-opsawg-veloce-yang.md
@@ -126,8 +126,12 @@ However, once the document is adopted as a WG item, the repository SHOULD reside
 of IETF controlled repository and managed by the WG.
 The name of the repository SHOULD reflect the name of the draft.
 In addition, the chairs MAY make sure that an appropriate CI/CD YANG validation is in place.
-It is RECOMMENDED that a containerized build environment be provided in the repository to enable local
-validation of YANG modules (e.g., via yanglint) independently of the CI/CD pipeline, and to ensure a consistent development environment across all contributors.
+It is RECOMMENDED that a real time collaborative working environment be provided in the repository
+to enable online validation of YANG modules (e.g., via yanglint)
+using the CI/CD pipeline, and to ensure a consistent development
+environment across all contributors.
+In addition, a containerized environment for local validation of YANG modules <bcp14>MAY</bcp14>
+also be provided in the repository as a backup.
 
 The procedure for managing WG documents (e.g., assign editors)
 applies for managing YANG modules (section 6.1 of IETF Working


### PR DESCRIPTION
replaces #27.
real time collaborative working environment vs containerized environment
I think online validation should be set to mandatory while the local validation is a backup
